### PR TITLE
Modifying arrow/keys selection behaviour

### DIFF
--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -201,6 +201,7 @@ var Typeahead = React.createClass({
     this.setState({searchResults: this.getOptionsForValue(optionString, this.props.options),
                    selection: formInputOptionString,
                    entryValue: optionString,
+                   selectionIndex: null,
                    showResults: false});
     return this.props.onOptionSelected(option, event);
   },

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -205,10 +205,11 @@ var Typeahead = React.createClass({
     return this.props.onOptionSelected(option, event);
   },
 
-  _onTextEntryUpdated: function() {
+  _onTextEntryUpdated: function(resetSelection = true) {
     var value = this.refs.entry.value;
+
     this.setState({searchResults: this.getOptionsForValue(value, this.props.options),
-                   selection: '',
+                   selection: resetSelection ? '' : this.state.selection,
                    entryValue: value});
   },
 
@@ -340,14 +341,14 @@ var Typeahead = React.createClass({
           onFocus={this._onFocus}
           onBlur={this._onBlur}
         />
-        { this.state.showResults && this._renderIncrementalSearchResults() }
+        { this._renderIncrementalSearchResults() }
       </div>
     );
   },
 
   _onFocus: function(event) {
     this.setState({isFocused: true, showResults: true}, function () {
-      this._onTextEntryUpdated();
+      this._onTextEntryUpdated(false);
     }.bind(this));
     if ( this.props.onFocus ) {
       return this.props.onFocus(event);
@@ -356,7 +357,7 @@ var Typeahead = React.createClass({
 
   _onBlur: function(event) {
     this.setState({isFocused: false}, function () {
-      this._onTextEntryUpdated();
+      this._onTextEntryUpdated(false);
     }.bind(this));
     if ( this.props.onBlur ) {
       return this.props.onBlur(event);

--- a/src/typeahead/index.js
+++ b/src/typeahead/index.js
@@ -206,7 +206,11 @@ var Typeahead = React.createClass({
     return this.props.onOptionSelected(option, event);
   },
 
-  _onTextEntryUpdated: function(resetSelection = true) {
+  _onTextEntryUpdated: function(resetSelection) {
+    if (typeof resetSelection === 'undefined') {
+      resetSelection = true;
+    }
+
     var value = this.refs.entry.value;
 
     this.setState({searchResults: this.getOptionsForValue(value, this.props.options),


### PR DESCRIPTION
### Goal

Modifying the original component behaviour to fit our needs.

### Details

There 2 different improvements:

####  Avoid displaying results if we have just selected one item.

- The onFocus and onBlur event handlers were modifying the selection
  property in the state, clearing it. That way after any of those
  events we were displaying search results no matter what.
- As a consequence if you select an item we were displaying afterwards
  a search result with the element we just displayed[1].

For instance:

![image](https://cloud.githubusercontent.com/assets/379269/23945046/4319bba8-0975-11e7-910c-802ad247294d.png)


#### Reset selectionIndex after an item is selected.

- Without this change we would preserve the latest selection index
  ending up in weird behaviour: i.e. you select the 4th element in the
  list, then you write something totally different and we will mark the
  4th item in the new results list even if had anything to do with the
  previous search.
