### PR TITLE
Renaming package to avoid circleCI cache conflict.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-typeahead",
+  "name": "cw-react-typeahead",
   "version": "2.0.0-alpha.7",
   "description": "React-based typeahead and typeahead-tokenizer",
   "keywords": [


### PR DESCRIPTION
### Goal

Rename the component to avoid conflicts in the circleCI build, otherwise the build process fails, seems that it's not able to find the new package's source, even if we launch the builds clearing the cache.

**Note:** This behaviour will needs further research, ideally we should preserve the original package name.